### PR TITLE
Avoid scrambling correspondence with inconsistent triangulation

### DIFF
--- a/lacecore/test_obj.py
+++ b/lacecore/test_obj.py
@@ -57,9 +57,7 @@ f 5 6 7 8
     with open(test_mesh_path, "w") as f:
         f.write(test_mesh_contents)
 
-    quad_mesh = load(test_mesh_path)
     # ABC + ACD
-    expected_triangle_faces = quad_mesh.f[:, [[0, 1, 2], [0, 2, 3]]].reshape(-1, 3)
-
+    expected_triangle_faces = np.array([[0, 1, 2], [0, 2, 3], [4, 5, 6], [4, 6, 7]])
     triangulated_mesh = load(test_mesh_path, triangulate=True)
     np.testing.assert_array_equal(triangulated_mesh.f, expected_triangle_faces)

--- a/lacecore/test_obj.py
+++ b/lacecore/test_obj.py
@@ -39,7 +39,7 @@ def test_triangulation_is_abc_acd(tmp_path):
     """
     There is some complex code in tinyobjloader which occasionally switches
     the axes of triangulation based on the vertex positions. This is
-    undesirable in lacecore; we always want ABC + ACD.
+    undesirable in lacecore as it scrambles correspondence.
     """
     test_mesh_path = str(tmp_path / "example.obj")
     test_mesh_contents = """

--- a/lacecore/test_obj.py
+++ b/lacecore/test_obj.py
@@ -33,3 +33,33 @@ def test_loads_from_local_path_using_serializer_failure_2():
     # test for failure
     with pytest.raises(ArityException):
         load("./examples/tinyobjloader/models/smoothing-group-two-squares.obj")
+
+
+def test_triangulation_is_abc_acd(tmp_path):
+    """
+    There is some complex code in tinyobjloader which occasionally switches
+    the axes of triangulation based on the vertex positions. This is
+    undesirable in lacecore; we always want ABC + ACD.
+    """
+    test_mesh_path = str(tmp_path / "example.obj")
+    test_mesh_contents = """
+v 0 0 0
+v 0 0 0
+v 0 0 0
+v 0 0 0
+f 1 2 3 4
+v 46.367584 82.676086 8.867414
+v 46.524185 82.81955 8.825487
+v 46.59864 83.086678 8.88121
+v 46.461926 82.834091 8.953863
+f 5 6 7 8
+    """
+    with open(test_mesh_path, "w") as f:
+        f.write(test_mesh_contents)
+
+    quad_mesh = load(test_mesh_path)
+    # ABC + ACD
+    expected_triangle_faces = quad_mesh.f[:, [[0, 1, 2], [0, 2, 3]]].reshape(-1, 3)
+
+    triangulated_mesh = load(test_mesh_path, triangulate=True)
+    np.testing.assert_array_equal(triangulated_mesh.f, expected_triangle_faces)


### PR DESCRIPTION
This adds a test case with a quad which was being triangulated differently in lacecore vs lace, and code which moves the triangulation into lacecore to avoid the complex triangulation logic happening in tinyobjloader.

Since we're optimizing for meshes in correspondence, it's important that triangulation is done without regard for the specific vertex positions, as taking them into account can scramble the correspondence as seen here.