### PR TITLE
Bump lacecore version

### DIFF
--- a/requirements_obj.txt
+++ b/requirements_obj.txt
@@ -1,2 +1,2 @@
 #tinyobjloader==2.0.0rc8
-tinymetabobjloader ==2.0.0rc9.dev0
+tinymetabobjloader ==2.0.0a0


### PR DESCRIPTION
Work around an issue in Poetry where dev releases like 2.0.0rc9.dev0 can't be installed