### PR TITLE
RELEASE 2.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.4.3
+
+- Revert previous change. This version does not support polliwog 3.0.0
+  prereleases.
+
+
 ## 2.4.2
 
 - Support polliwog 3.0.0 prereleases.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 python = ">=3.7,<4"
 numpy = "<1.19.0"
 ounce = ">=1.1.0,<2.0"
-polliwog = ">=2.1.0,<=3.0.0"
+polliwog = ">=2.1.0,<3.0"
 # polliwog = {git = "https://github.com/lace/polliwog.git", branch = "slice-mapping"}
 tinymetabobjloader = {version = "2.0.0a0", optional = true}
 vg = ">=2.0.0"


### PR DESCRIPTION
Was running into problems using 2.4.2 with polliwog 3.0.0a3. Will fix in a follow-up PR.